### PR TITLE
Fixes issue #12 - Fails to run on yarn sub-process

### DIFF
--- a/files/.jsig/index.js
+++ b/files/.jsig/index.js
@@ -1,7 +1,7 @@
 var ChildProcess = require("child_process");
 var Path = require("path");
 
-var jsigVersion = "0.1.5";
+var jsigVersion = "0.1.6";
 
 module.exports = {
   version: jsigVersion,

--- a/files/.jsig/jsig-yarn.js
+++ b/files/.jsig/jsig-yarn.js
@@ -9,11 +9,11 @@ var FS = require("fs");
 var jsig = require("./index");
 
 // Work out where the actual yarn installation is
-var actualYarn;
+var yarnJsFile;
 
-if(process.env.jsig_yarn_file) {
+if (process.env.jsig_yarn_js_file) {
   // We're in a sub-process yarn, so use the original (top-level) one.
-  actualYarn = process.env.jsig_yarn_file;
+  yarnJsFile = process.env.jsig_yarn_js_file;
 } else {
   try {
     var yarnFile = ChildProcess.execSync("which yarn").toString().trim();
@@ -37,10 +37,10 @@ if(process.env.jsig_yarn_file) {
       }
     }
 
-    actualYarn = Path.resolve(yarnDir, "yarn.js");
+    yarnJsFile = Path.resolve(yarnDir, "yarn.js");
 
     // Store the actual Yarn dir in an env var so that child processes can pick it up
-    process.env.jsig_yarn_file = actualYarn;
+    process.env.jsig_yarn_js_file = yarnJsFile;
   } catch (e) {
     //  TODO: Add a way of specifying the yarn executable
     console.error(
@@ -53,4 +53,4 @@ if(process.env.jsig_yarn_file) {
 
 jsig.init(false);
 
-require(actualYarn);
+require(yarnJsFile);

--- a/files/.jsig/jsig-yarn.js
+++ b/files/.jsig/jsig-yarn.js
@@ -9,38 +9,48 @@ var FS = require("fs");
 var jsig = require("./index");
 
 // Work out where the actual yarn installation is
-var yarnDir;
+var actualYarn;
 
-try {
-  var yarnFile = ChildProcess.execSync("which yarn").toString().trim();
+if(process.env.jsig_yarn_file) {
+  // We're in a sub-process yarn, so use the original (top-level) one.
+  actualYarn = process.env.jsig_yarn_file;
+} else {
+  try {
+    var yarnFile = ChildProcess.execSync("which yarn").toString().trim();
 
-  yarnDir = Path.dirname(FS.realpathSync(yarnFile));
+    var yarnDir = Path.dirname(FS.realpathSync(yarnFile));
 
-  // If 'yarn.js' isn't in the same dir as the yarn' script
-  // then we will try and parse its location from the script.
-  // This seems to happen in some Hmoebrew installations
-  if (!FS.existsSync(Path.resolve(yarnDir, "yarn.js"))) {
-    var yarnScript = FS.readFileSync(yarnFile).toString();
+    // If 'yarn.js' isn't in the same dir as the yarn' script
+    // then we will try and parse its location from the script.
+    // This seems to happen in some Hmoebrew installations
+    if (!FS.existsSync(Path.resolve(yarnDir, "yarn.js"))) {
+      var yarnScript = FS.readFileSync(yarnFile).toString();
 
-    var match = yarnScript.match(/([^'"]+)\/yarn\.js/);
+      var match = yarnScript.match(/([^'"]+)\/yarn\.js/);
 
-    if (match) {
-      yarnDir = match[1];
-    } else {
-      throw new Error(
-        `Could not determine yarn.js path from yarn script ${yarnScript}`
-      );
+      if (match) {
+        yarnDir = match[1];
+      } else {
+        throw new Error(
+          `Could not determine yarn.js path from yarn script ${yarnScript}`
+        );
+      }
     }
+
+    actualYarn = Path.resolve(yarnDir, "yarn.js");
+
+    // Store the actual Yarn dir in an env var so that child processes can pick it up
+    process.env.jsig_yarn_file = actualYarn;
+  } catch (e) {
+    //  TODO: Add a way of specifying the yarn executable
+    console.error(
+      "🛑   JSInstallGuard: Could not find yarn executable using 'which yarn'"
+    );
+    console.error("🛑   JSInstallGuard:", e.message);
+    process.exit(1);
   }
-} catch (e) {
-  //  TODO: Add a way of specifying the yarn executable
-  console.error(
-    "🛑   JSInstallGuard: Could not find yarn executable using 'which yarn'"
-  );
-  console.error("🛑   JSInstallGuard:", e.message);
-  process.exit(1);
 }
 
 jsig.init(false);
 
-require(Path.resolve(yarnDir, "yarn.js"));
+require(actualYarn);

--- a/files/.jsig/jsig-yarn.js
+++ b/files/.jsig/jsig-yarn.js
@@ -22,7 +22,7 @@ if (process.env.jsig_yarn_js_file) {
 
     // If 'yarn.js' isn't in the same dir as the yarn' script
     // then we will try and parse its location from the script.
-    // This seems to happen in some Hmoebrew installations
+    // This seems to happen in some Homebrew installations
     if (!FS.existsSync(Path.resolve(yarnDir, "yarn.js"))) {
       var yarnScript = FS.readFileSync(yarnFile).toString();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsinstallguard",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Small security wrapper around the package manager which intercepts any preistall and postinstall scripts.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes issue #12 by storing the yarn executable in the environment for the top level yarn process, and just using that for all the sub-processes.